### PR TITLE
Fix findFirst query for bun:sqlite

### DIFF
--- a/drizzle-orm/src/bun-sqlite/session.ts
+++ b/drizzle-orm/src/bun-sqlite/session.ts
@@ -133,7 +133,7 @@ export class PreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> 
 	get(placeholderValues?: Record<string, unknown>): T['get'] {
 		const params = fillPlaceholders(this.query.params, placeholderValues ?? {});
 		this.logger.logQuery(this.query.sql, params);
-		const row = this.stmt.get(...params);
+		const row = this.stmt.values(...params)[0];
 
 		if (!row) {
 			return undefined;


### PR DESCRIPTION
This commit fixes bug in bun:sqlite session implementation where findFirst query failed because of differences in return type of bun:sqlite's Statement.get() and Statement.values()